### PR TITLE
Hw6

### DIFF
--- a/tasks/CMakeLists.txt
+++ b/tasks/CMakeLists.txt
@@ -2,4 +2,5 @@ include(${PROJECT_SOURCE_DIR}/cmake/common.cmake)
 
 add_subdirectory(local_shadertoy1)
 add_subdirectory(local_shadertoy2)
+add_subdirectory(inflight_frames)
 add_subdirectory(model_bakery)

--- a/tasks/inflight_frames/App.cpp
+++ b/tasks/inflight_frames/App.cpp
@@ -1,0 +1,299 @@
+#include "App.hpp"
+
+#include <etna/Etna.hpp>
+#include <etna/GlobalContext.hpp>
+#include <etna/PipelineManager.hpp>
+#include <etna/Profiling.hpp>
+#include <etna/RenderTargetStates.hpp>
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+#include <etna/BlockingTransferHelper.hpp>
+#include <iostream>
+#include <ctime>
+
+
+App::App()
+  : resolution{1280, 720}
+  , skinTextureResolution{128, 128}
+  , useVsync{true}
+{
+  {
+    auto glfwInstExts = windowing.getRequiredVulkanInstanceExtensions();
+
+    std::vector<const char*> instanceExtensions{glfwInstExts.begin(), glfwInstExts.end()};
+
+    std::vector<const char*> deviceExtensions{VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+
+    etna::initialize(etna::InitParams{
+      .applicationName = "Local Shadertoy",
+      .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
+      .instanceExtensions = instanceExtensions,
+      .deviceExtensions = deviceExtensions,
+      .physicalDeviceIndexOverride = {},
+      .numFramesInFlight = framesInFlight,
+    });
+  }
+
+  osWindow = windowing.createWindow(OsWindow::CreateInfo{
+    .resolution = resolution,
+  });
+
+  {
+    auto surface = osWindow->createVkSurface(etna::get_context().getInstance());
+
+    vkWindow = etna::get_context().createWindow(etna::Window::CreateInfo{
+      .surface = std::move(surface),
+    });
+
+    auto [w, h] = vkWindow->recreateSwapchain(etna::Window::DesiredProperties{
+      .resolution = {resolution.x, resolution.y},
+      .vsync = useVsync,
+    });
+
+    resolution = {w, h};
+  }
+
+  commandManager = etna::get_context().createPerFrameCmdMgr();
+  oneShotManager = etna::get_context().createOneShotCmdMgr();
+
+  {
+    etna::create_program("shadertoy2", {INFLIGHT_FRAMES_SHADERS_ROOT "toy.vert.spv",
+                                        INFLIGHT_FRAMES_SHADERS_ROOT "toy.frag.spv" });
+    etna::create_program("skinTexture", {INFLIGHT_FRAMES_SHADERS_ROOT "toy.vert.spv",
+                                        INFLIGHT_FRAMES_SHADERS_ROOT "texture.frag.spv" });
+
+    
+    fragVertPipeline = etna::get_context().getPipelineManager().createGraphicsPipeline("shadertoy2",
+      etna::GraphicsPipeline::CreateInfo {
+        .fragmentShaderOutput = {
+          .colorAttachmentFormats = {vk::Format::eB8G8R8A8Srgb}
+        }
+      });
+    
+    skinTexturePipeline = etna::get_context().getPipelineManager().createGraphicsPipeline("skinTexture",
+      etna::GraphicsPipeline::CreateInfo {
+        .fragmentShaderOutput = {
+          .colorAttachmentFormats = {vk::Format::eB8G8R8A8Srgb}
+        }
+      });
+
+    skinTextureImage = etna::get_context().createImage(etna::Image::CreateInfo{
+      .extent = vk::Extent3D{skinTextureResolution.x, skinTextureResolution.y, 1},
+      .name = "skinTexture",
+      .format = vk::Format::eB8G8R8A8Srgb,
+      .imageUsage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled,
+    });
+
+    defaultSampler = etna::Sampler(etna::Sampler::CreateInfo
+      {
+        .filter = vk::Filter::eLinear,
+        .addressMode = vk::SamplerAddressMode::eRepeat,
+        .name = "default_sampler"
+      });
+    
+    for (size_t i = 0; i < framesInFlight; ++i) {
+      params[i] = etna::get_context().createBuffer(etna::Buffer::CreateInfo{
+        .size = sizeof(Params),
+        .bufferUsage = vk::BufferUsageFlagBits::eUniformBuffer,
+        .memoryUsage = VMA_MEMORY_USAGE_CPU_ONLY,
+        .name = "params",
+      });
+
+      params[i].map();
+    }
+  }
+}
+
+App::~App()
+{
+  ETNA_CHECK_VK_RESULT(etna::get_context().getDevice().waitIdle());
+}
+
+void App::run()
+{
+  while (!osWindow->isBeingClosed())
+  {
+    ZoneScopedN("Frame");
+
+    {
+      ZoneScopedN("Poll window events");
+      windowing.poll();
+    }
+
+    drawFrame();
+
+    FrameMark;
+  }
+
+  ETNA_CHECK_VK_RESULT(etna::get_context().getDevice().waitIdle());
+}
+
+void App::drawFrame()
+{
+  ZoneScoped;
+  auto currentCmdBuf = commandManager->acquireNext();
+
+  if (!initializedFileTexture) {
+    int x, y, n;
+    unsigned char *picData = stbi_load(TEXTURES_ROOT "texture1.bmp", &x, &y, &n, 4);
+    if (picData == NULL) {
+      throw "texture1.bmp not found";
+    }
+
+    etna::Image::CreateInfo fileTextureInfo{
+      .extent = vk::Extent3D{static_cast<uint32_t>(x), static_cast<uint32_t>(y), 1},
+      .name = "fileTexture",
+      .format = vk::Format::eR8G8B8A8Srgb,
+      .imageUsage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled,
+    };
+    fileTextureImage = etna::create_image_from_bytes(fileTextureInfo, currentCmdBuf, picData);
+
+    stbi_image_free(picData);
+    initializedFileTexture = true;
+  }
+
+  etna::begin_frame();
+
+  auto nextSwapchainImage = vkWindow->acquireNext();
+
+  if (nextSwapchainImage)
+  {
+    auto [backbuffer, backbufferView, backbufferAvailableSem] = *nextSwapchainImage;
+
+    ETNA_CHECK_VK_RESULT(currentCmdBuf.begin(vk::CommandBufferBeginInfo{}));
+    {
+      ETNA_PROFILE_GPU(currentCmdBuf, "Frame");
+
+      etna::set_state(
+        currentCmdBuf,
+        skinTextureImage.get(),
+        vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+        vk::AccessFlagBits2::eColorAttachmentWrite,
+        vk::ImageLayout::eColorAttachmentOptimal,
+        vk::ImageAspectFlagBits::eColor);
+      
+      etna::flush_barriers(currentCmdBuf);
+
+      {
+        ETNA_PROFILE_GPU(currentCmdBuf, "ProceduralSkinTexture");
+
+        etna::RenderTargetState state{currentCmdBuf, {{}, {skinTextureResolution.x, skinTextureResolution.y}},
+          {{skinTextureImage.get(), skinTextureImage.getView({})}}, {}};
+        auto skinInfo = etna::get_shader_program("skinTexture");
+
+        currentCmdBuf.bindPipeline(vk::PipelineBindPoint::eGraphics, skinTexturePipeline.getVkPipeline());
+
+        glm::uvec2 res = skinTextureResolution;
+        currentCmdBuf.pushConstants(
+          skinTexturePipeline.getVkPipelineLayout(), vk::ShaderStageFlagBits::eFragment,
+          0, sizeof(res), &res);
+
+        currentCmdBuf.draw(3, 1, 0, 0);
+      }
+
+
+      etna::set_state(
+        currentCmdBuf,
+        skinTextureImage.get(),
+        vk::PipelineStageFlagBits2::eFragmentShader,
+        vk::AccessFlagBits2::eColorAttachmentRead,
+        vk::ImageLayout::eShaderReadOnlyOptimal,
+        vk::ImageAspectFlagBits::eColor);
+      
+      etna::set_state(
+        currentCmdBuf,
+        fileTextureImage.get(),
+        vk::PipelineStageFlagBits2::eFragmentShader,
+        vk::AccessFlagBits2::eColorAttachmentRead,
+        vk::ImageLayout::eShaderReadOnlyOptimal,
+        vk::ImageAspectFlagBits::eColor);
+
+      etna::set_state(
+        currentCmdBuf,
+        backbuffer,
+        vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+        vk::AccessFlagBits2::eColorAttachmentWrite,
+        vk::ImageLayout::eColorAttachmentOptimal,
+        vk::ImageAspectFlagBits::eColor);
+
+      etna::flush_barriers(currentCmdBuf);
+
+      {
+        ZoneScopedN("Simulated workload");
+        std::this_thread::sleep_for(std::chrono::milliseconds(8));  // simulate workload
+      }
+
+      {
+        ETNA_PROFILE_GPU(currentCmdBuf, "MainImage");
+
+        etna::RenderTargetState state{currentCmdBuf, {{}, {resolution.x, resolution.y}},
+          {{backbuffer, backbufferView}}, {}};
+
+        auto fragVertInfo = etna::get_shader_program("shadertoy2");
+
+        
+        Params freshParams{
+          resolution,
+          glm::ivec2{osWindow->mouse.freePos}
+        };
+
+        std::memcpy(params[currentBuffer].data(), &freshParams, sizeof(freshParams));
+
+        auto set = etna::create_descriptor_set(
+          fragVertInfo.getDescriptorLayoutId(0),
+          currentCmdBuf,
+          {
+            etna::Binding{0, skinTextureImage.genBinding(defaultSampler.get(), vk::ImageLayout::eShaderReadOnlyOptimal)},
+            etna::Binding{1, fileTextureImage.genBinding(defaultSampler.get(), vk::ImageLayout::eShaderReadOnlyOptimal)},
+            etna::Binding{2, params[currentBuffer].genBinding()},
+          });
+        currentBuffer = (currentBuffer + 1) % framesInFlight;
+
+        vk::DescriptorSet vkSet = set.getVkSet();
+
+        currentCmdBuf.bindPipeline(vk::PipelineBindPoint::eGraphics, fragVertPipeline.getVkPipeline());
+        currentCmdBuf.bindDescriptorSets(
+          vk::PipelineBindPoint::eGraphics, fragVertPipeline.getVkPipelineLayout(), 0, 1, &vkSet, 0, nullptr);
+
+        /*
+        currentCmdBuf.pushConstants(
+          fragVertPipeline.getVkPipelineLayout(), vk::ShaderStageFlagBits::eFragment,
+          0, sizeof(res), &res);
+        */
+
+        currentCmdBuf.draw(3, 1, 0, 0);
+      }
+
+      etna::set_state(
+        currentCmdBuf,
+        backbuffer,
+        vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+        {},
+        vk::ImageLayout::ePresentSrcKHR,
+        vk::ImageAspectFlagBits::eColor);
+      etna::flush_barriers(currentCmdBuf);
+
+      ETNA_READ_BACK_GPU_PROFILING(currentCmdBuf);
+    }
+    ETNA_CHECK_VK_RESULT(currentCmdBuf.end());
+
+    auto renderingDone =
+      commandManager->submit(std::move(currentCmdBuf), std::move(backbufferAvailableSem));
+
+    const bool presented = vkWindow->present(std::move(renderingDone), backbufferView);
+
+    if (!presented)
+      nextSwapchainImage = std::nullopt;
+  }
+
+  etna::end_frame();
+
+  if (!nextSwapchainImage && osWindow->getResolution() != glm::uvec2{0, 0})
+  {
+    auto [w, h] = vkWindow->recreateSwapchain(etna::Window::DesiredProperties{
+      .resolution = {resolution.x, resolution.y},
+      .vsync = useVsync,
+    });
+    ETNA_VERIFY((resolution == glm::uvec2{w, h}));
+  }
+}

--- a/tasks/inflight_frames/App.hpp
+++ b/tasks/inflight_frames/App.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <etna/Sampler.hpp>
+#include <etna/GlobalContext.hpp>
+#include <etna/Window.hpp>
+#include <etna/PerFrameCmdMgr.hpp>
+#include <etna/ComputePipeline.hpp>
+#include <etna/GraphicsPipeline.hpp>
+#include <etna/Image.hpp>
+
+#include "wsi/OsWindowingManager.hpp"
+
+
+class App
+{
+public:
+  App();
+  ~App();
+
+  void run();
+
+private:
+  void drawFrame();
+
+private:
+  static constexpr size_t framesInFlight = 3;
+
+  struct Params {
+    glm::uvec2 resolution;
+    glm::ivec2 mousePos;
+  };
+
+  etna::Buffer params[framesInFlight];
+  size_t currentBuffer = 0;
+
+  OsWindowingManager windowing;
+  std::unique_ptr<OsWindow> osWindow;
+
+  glm::uvec2 resolution;
+  glm::uvec2 skinTextureResolution;
+  bool useVsync;
+
+  etna::GraphicsPipeline skinTexturePipeline;
+  etna::GraphicsPipeline fragVertPipeline;
+  etna::Image skinTextureImage;
+  etna::Image fileTextureImage;
+  etna::Sampler defaultSampler;
+
+  std::unique_ptr<etna::Window> vkWindow;
+  std::unique_ptr<etna::PerFrameCmdMgr> commandManager;
+  std::unique_ptr<etna::OneShotCmdMgr> oneShotManager;
+
+  bool initializedFileTexture = false;
+};

--- a/tasks/inflight_frames/CMakeLists.txt
+++ b/tasks/inflight_frames/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(inflight_frames
+  main.cpp
+  App.cpp
+)
+
+target_link_libraries(inflight_frames
+  PRIVATE glfw etna glm::glm wsi gui)
+
+target_add_shaders(inflight_frames
+  shaders/toy.vert
+  shaders/toy.frag
+  shaders/texture.frag
+)
+
+target_link_libraries(inflight_frames PUBLIC render_utils scene)
+
+add_compile_definitions(inflight_frames PRIVATE TEXTURES_ROOT="${PROJECT_SOURCE_DIR}/resources/textures/")

--- a/tasks/inflight_frames/main.cpp
+++ b/tasks/inflight_frames/main.cpp
@@ -1,0 +1,17 @@
+#include "App.hpp"
+
+#include <etna/Etna.hpp>
+
+
+int main()
+{
+  {
+    App app;
+    app.run();
+  }
+
+  if (etna::is_initilized())
+    etna::shutdown();
+
+  return 0;
+}

--- a/tasks/inflight_frames/shaders/texture.frag
+++ b/tasks/inflight_frames/shaders/texture.frag
@@ -1,0 +1,90 @@
+#version 430
+#extension GL_GOOGLE_include_directive : require
+
+
+#include "cpp_glsl_compat.h"
+
+
+layout(location = 0) out vec4 out_fragColor;
+
+layout(push_constant) uniform params_t
+{
+  uvec2 resolution;
+} params;
+
+
+// code stolen from here: https://www.shadertoy.com/view/lsf3WH
+
+// 0: integer hash
+// 1: float hash (aliasing based) (don't do this unless you live in the year 2013)
+#define METHOD 0
+
+// 0: cubic
+// 1: quintic
+#define INTERPOLANT 0
+
+#if METHOD==0
+float hash( in ivec2 p )  // this hash is not production ready, please
+{                         // replace this by something better
+
+    // 2D -> 1D
+    int n = p.x*3 + p.y*113;
+
+    // 1D hash by Hugo Elias
+	n = (n << 13) ^ n;
+    n = n * (n * n * 15731 + 789221) + 1376312589;
+    return -1.0+2.0*float( n & 0x0fffffff)/float(0x0fffffff);
+}
+#else
+float hash(vec2 p)  // replace this by something better
+{
+    p  = 50.0*fract( p*0.3183099 + vec2(0.71,0.113));
+    return -1.0+2.0*fract( p.x*p.y*(p.x+p.y) );
+}
+#endif
+
+float noise( in vec2 p )
+{
+    #if METHOD==0
+    ivec2 i = ivec2(floor( p ));
+    #else
+    vec2 i = floor( p );
+    #endif
+    vec2 f = fract( p );
+	
+    #if INTERPOLANT==1
+    // quintic interpolant
+    vec2 u = f*f*f*(f*(f*6.0-15.0)+10.0);
+    #else
+    // cubic interpolant
+    vec2 u = f*f*(3.0-2.0*f);
+    #endif    
+
+    #if METHOD==0
+    return mix( mix( hash( i + ivec2(0,0) ), 
+                     hash( i + ivec2(1,0) ), u.x),
+                mix( hash( i + ivec2(0,1) ), 
+                     hash( i + ivec2(1,1) ), u.x), u.y);
+    #else
+    return mix( mix( hash( i + vec2(0.0,0.0) ), 
+                     hash( i + vec2(1.0,0.0) ), u.x),
+                mix( hash( i + vec2(0.0,1.0) ), 
+                     hash( i + vec2(1.0,1.0) ), u.x), u.y);
+    #endif
+}
+
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / params.resolution;
+  
+  float f = 0.0;   
+  uv *= 8.0;
+      mat2 m = mat2( 1.6,  1.2, -1.2,  1.6 );
+  	f  = 0.5000*noise( uv ); uv = m*uv;
+  	f += 0.2500*noise( uv ); uv = m*uv;
+  	f += 0.1250*noise( uv ); uv = m*uv;
+  	f += 0.0625*noise( uv ); uv = m*uv;  
+  f = 0.5 + 0.5*f;
+
+  out_fragColor = vec4( f*0.6, f*0.6, 0., 1.0 );
+}

--- a/tasks/inflight_frames/shaders/toy.comp
+++ b/tasks/inflight_frames/shaders/toy.comp
@@ -1,0 +1,200 @@
+#version 430
+
+layout(local_size_x = 32, local_size_y = 16) in;
+
+layout(binding = 0, rgba8) uniform image2D resultImage;
+
+const vec2 iResolution = vec2(1280, 720);
+const float iTime = 10.0f;
+
+// --- START SHADERTOY COPYPASTA ---
+const float PI = 3.14159265359;
+
+const vec3 background_color = vec3(0.3, 0.7, 0.9);
+const float shape_tolerance = 1.0; // (0; inf) how smooth will shape transition be
+const float color_mix_sharpness = 10.0; // (1; inf) how sharp will color transition
+const float trefoil_size = 6.0; // how big the whole thing is
+const float radius = 0.5;
+
+struct sphere {
+    vec3 center;
+    float radius;
+    vec3 color;
+};
+
+
+const int n_spheres = 24;
+sphere spheres[n_spheres] = sphere[](
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0))
+);
+
+const bool metal_reflection = false;
+
+
+struct light{
+    vec3 position;
+    float strength;
+    vec3 color;
+};
+
+const int n_lights = 1;
+light lights[n_lights] = light[](
+    light(vec3(0, 0, -100.0), 10000.0, vec3(1, 1, 1))
+);
+
+
+float sphere_sdf(in vec3 point, in vec3 center, in float radius) {
+    return length(point - center) - radius;
+}
+
+// Color weight field - determines how much of a shape's color should be used.
+float sphere_cwf(in vec3 point, in vec3 center, in float radius) {
+    return pow(color_mix_sharpness, radius - (length(point - center)));
+}
+
+float sdf(in vec3 point) {
+    float sum = 0.0;
+    for (int i = 0; i < n_spheres; ++i) {
+        float dist = sphere_sdf(point, spheres[i].center, spheres[i].radius);
+        sum += exp2(-dist / shape_tolerance);
+    }
+    return -shape_tolerance * log2(sum);
+}
+
+vec3 base_color(in vec3 point) {
+    vec3 color_num = vec3(0, 0, 0);
+    vec3 color_denom = vec3(0, 0, 0);
+    for (int i = 0; i < n_spheres; ++i) {
+        float cwf = sphere_cwf(point, spheres[i].center, spheres[i].radius);
+        color_num += spheres[i].color * cwf;
+        color_denom += cwf;
+    }
+    return color_num / color_denom;
+}
+
+bool traceRay(in vec3 ray, in vec3 pos, out vec3 impact_point) {
+    while (true) {
+        float dist = abs(sdf(pos));
+    
+        if (dist < 0.01) {
+            impact_point = pos;
+            return true;
+        }
+        
+        if (dist > 100.0) {
+            return false;
+        }
+        
+        pos += ray * dist;
+    }
+}
+
+vec3 grad(in vec3 point, in float delta) {
+    vec3 dx = vec3(delta, 0, 0);
+    vec3 dy = vec3(0, delta, 0);
+    vec3 dz = vec3(0, 0, delta);
+    float y0 = sdf(point);
+    return (vec3(sdf(point+dx), sdf(point+dy), sdf(point+dz)) - vec3(y0, y0, y0)) / delta;
+}
+
+
+vec3 diffuse(in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray = lights[i].position - point;
+        float intensity = lights[i].strength / pow(length(lightray), 2.0);
+        result += max(dot(normal, normalize(lightray)), 0.0) * intensity * lights[i].color;
+    }
+    result *= base_color;
+    return result;
+}
+
+vec3 specular(in vec3 eye, in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 eye_ray = normalize(eye - point);
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray_refl = -reflect(lights[i].position - point, normal);
+        float intensity = lights[i].strength / pow(length(lightray_refl), 2.0);
+        float powered = pow(max(dot(eye_ray, normalize(lightray_refl)), 0.0), 20.0);
+        result += powered * intensity * lights[i].color;
+    }
+    
+    if (metal_reflection) {
+        result *= base_color;
+    }
+    return result;
+}
+
+void positionSpheres() {
+    for (int i = 0; i < n_spheres; ++i) {
+        float t = iTime + PI * float(i) / float(n_spheres);
+        spheres[i].center = vec3(trefoil_size * cos(3.0 * t) * sin(t) + sin(2.0 * t) * 0.2,
+                                 trefoil_size * cos(3.0 * t) * cos(t) + sin(t) * 0.2,
+                                 33.0 + 30.0 * sin(t * 0.5));
+    }
+}
+
+// --- PAUSE SHADERTOY COPYPASTA
+
+
+void main()
+{
+  ivec2 iuv = ivec2(gl_GlobalInvocationID.xy);
+
+  // TODO: Put your shadertoy code here!
+
+  // --- CONTINUE SHADERTOY COPYPASTA
+  positionSpheres();
+
+  vec2 uv = (iuv - iResolution.xy / 2.0) / min(iResolution.x, iResolution.y);
+
+  vec3 camera = vec3(0, 0, -1);
+  vec3 ray = normalize(vec3(uv, 0) - camera);
+  vec3 surface_point;
+  vec3 color;
+  if (traceRay(ray, camera, surface_point)) {
+      vec3 base = base_color(surface_point);
+      color = specular(camera, surface_point, base) + diffuse(surface_point, base) + background_color * base * 0.5;
+  } else {
+      color = background_color;
+  }
+  
+  imageStore(resultImage, iuv, vec4(color, 1));
+
+  // --- END SHADERTOY COPYPASTA
+
+  /* --- DEFAULT CODE COMMENTED ---
+  // Simple gradient as a test.
+  vec3 color = vec3(vec2(uv) / vec2(1280, 720), 0);
+
+  if (uv.x < 1280 && uv.y < 720)
+    imageStore(resultImage, uv, vec4(color, 1));
+  */
+}

--- a/tasks/inflight_frames/shaders/toy.frag
+++ b/tasks/inflight_frames/shaders/toy.frag
@@ -1,0 +1,236 @@
+#version 430
+#extension GL_GOOGLE_include_directive : require
+
+
+#include "cpp_glsl_compat.h"
+
+
+layout(binding = 0) uniform sampler2D iChannel0;
+layout(binding = 1) uniform sampler2D fileTexture;
+
+layout(binding = 2) uniform params_t
+{
+  uvec2 resolution;
+  ivec2 mousePos;
+} params;
+
+layout(location = 0) out vec4 out_fragColor;
+
+
+const float iTime = 10.0f;
+
+const float PI = 3.14159265359;
+
+const float shape_tolerance = 1.0; // (0; inf) how smooth will shape transition be
+const float color_mix_sharpness = 10.; // (1; inf) how sharp will color transition
+const float trefoil_size = 6.0; // how big the whole thing is
+const float radius = 0.5;
+
+
+struct sphere {
+    vec3 center;
+    float radius;
+    vec3 color;
+};
+
+
+const int n_spheres = 24;
+sphere spheres[n_spheres] = sphere[](
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0))
+);
+
+const bool metal_reflection = false;
+
+
+struct light{
+    vec3 position;
+    float strength;
+    vec3 color;
+};
+
+const int n_lights = 1;
+light lights[n_lights] = light[](
+    light(vec3(0, 0, -100.0), 10000.0, vec3(1, 1, 1))
+);
+
+vec3 grad(in vec3 point, in float delta);
+
+float sphere_sdf(in vec3 point, in vec3 center, in float radius) {
+    return length(point - center) - radius;
+}
+
+// Color weight field - determines how much of a shape's color should be used.
+float sphere_cwf(in vec3 point, in vec3 center, in float radius) {
+    return pow(color_mix_sharpness, radius - (length(point - center)));
+}
+
+float sdf(in vec3 point) {
+    float sum = 0.0;
+    for (int i = 0; i < n_spheres; ++i) {
+        float dist = sphere_sdf(point, spheres[i].center, spheres[i].radius);
+        sum += exp2(-dist / shape_tolerance);
+    }
+    return -shape_tolerance * log2(sum);
+}
+
+vec3 get_sphere_texture_color(in sphere sph, in vec3 point) {
+    point -= sph.center + vec3(2.0);
+    point /= 20.0;
+    vec3 normal = normalize(abs(point * 20.0 + vec3(2.0)));
+    vec3 result_procedural = normal.x * texture(iChannel0, point.yz).rgb +
+    normal.y * texture(iChannel0, point.xz).rgb +
+    normal.z * texture(iChannel0, point.xy).rgb;
+    vec3 result_file = normal.x * texture(fileTexture, point.yz).rgb +
+    normal.y * texture(fileTexture, point.xz).rgb +
+    normal.z * texture(fileTexture, point.xy).rgb;
+
+    float mix_factor = 0.5f;
+    vec3 result = mix_factor * result_procedural + (1.0f - mix_factor) * result_file;
+    return result * 1.5;
+}
+
+vec3 base_color(in vec3 point) {
+    vec3 color_num = vec3(0, 0, 0);
+    vec3 color_denom = vec3(0, 0, 0);
+    for (int i = 0; i < n_spheres; ++i) {
+        float cwf = sphere_cwf(point, spheres[i].center, spheres[i].radius);
+        color_num += get_sphere_texture_color(spheres[i], point) * cwf;
+        color_denom += cwf;
+    }
+    return color_num / color_denom;
+}
+
+void simulate_workload(inout vec3 useful) {
+    for (int i = 0; i < 9000; i++) {
+        if (i % 2 == 0) {
+            useful += vec3(0.001);
+        } else {
+            useful -= vec3(0.001);
+        }
+    }
+}
+
+bool traceRay(in vec3 ray, in vec3 pos, out vec3 impact_point) {
+    simulate_workload(impact_point);
+
+    while (true) {
+        float dist = abs(sdf(pos));
+    
+        if (dist < 0.01) {
+            impact_point = pos;
+            return true;
+        }
+        
+        if (dist > 100.0) {
+            return false;
+        }
+        
+        pos += ray * dist;
+    }
+}
+
+vec3 grad(in vec3 point, in float delta) {
+    vec3 dx = vec3(delta, 0, 0);
+    vec3 dy = vec3(0, delta, 0);
+    vec3 dz = vec3(0, 0, delta);
+    float y0 = sdf(point);
+    return (vec3(sdf(point+dx), sdf(point+dy), sdf(point+dz)) - vec3(y0, y0, y0)) / delta;
+}
+
+
+vec3 diffuse(in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray = lights[i].position - point;
+        float intensity = lights[i].strength / pow(length(lightray), 2.0);
+        result += max(dot(normal, normalize(lightray)), 0.0) * intensity * lights[i].color;
+    }
+    result *= base_color;
+    return result;
+}
+
+vec3 specular(in vec3 eye, in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 eye_ray = normalize(eye - point);
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray_refl = -reflect(lights[i].position - point, normal);
+        float intensity = lights[i].strength / pow(length(lightray_refl), 2.0);
+        float powered = pow(max(dot(eye_ray, normalize(lightray_refl)), 0.0), 20.0);
+        result += powered * intensity * lights[i].color;
+    }
+    
+    if (metal_reflection) {
+        result *= base_color;
+    }
+    return result;
+}
+
+void positionSpheres() {
+    for (int i = 0; i < n_spheres; ++i) {
+        //float t = iTime + PI * float(i) / float(n_spheres);
+        float t = iTime + PI * float(i) / float(n_spheres);
+        spheres[i].center = vec3(trefoil_size * cos(3.0 * t) * sin(t) + sin(2.0 * t) * 0.2,
+                                 trefoil_size * cos(3.0 * t) * cos(t) + sin(t) * 0.2,
+                                 36.0 + 30.0 * sin(t * 0.5 + PI / 4.));
+    }
+}
+
+vec3 skybox_color(in vec3 direction) {
+    // return texture(iChannel1, direction).rgb;
+    return vec3(0.3, 0.05, 0.05);
+}
+
+
+void main() {
+  // White circle around mouse.
+  if (length(gl_FragCoord.xy - params.mousePos) < 10.0f) {
+    out_fragColor = vec4(1.0f);
+    return;
+  }
+
+  positionSpheres();
+
+  vec2 uv = (gl_FragCoord.xy - params.resolution.xy / 2.0) / min(params.resolution.x, params.resolution.y);
+
+  vec3 camera = vec3(0, 0, -1);
+  vec3 ray = normalize(vec3(uv, 0) - camera);
+  vec3 surface_point;
+  vec3 color;
+  if (traceRay(ray, camera, surface_point)) {
+      vec3 base = base_color(surface_point);
+      vec3 normal = normalize(grad(surface_point, 0.0001));
+      vec3 skyray = reflect(ray, normal);
+      color = specular(camera, surface_point, base) + diffuse(surface_point, base);
+  } else {
+      color = skybox_color(ray);
+  }
+  
+  out_fragColor = vec4(color, 1.0f);
+}

--- a/tasks/inflight_frames/shaders/toy.vert
+++ b/tasks/inflight_frames/shaders/toy.vert
@@ -1,0 +1,17 @@
+#version 430
+#extension GL_GOOGLE_include_directive : require
+
+
+#include "cpp_glsl_compat.h"
+
+
+void main(void)
+{
+  if (gl_VertexIndex == 0) {
+    gl_Position = vec4(-1.0f, -1.0f, 0.0f, 1.0f);
+  } else if (gl_VertexIndex == 1) {
+    gl_Position = vec4(3.0f, -1.0f, 0.0f, 1.0f);
+  } else {
+    gl_Position = vec4(-1.0f, 3.0f, 0.0f, 1.0f);
+  }
+}

--- a/tasks/local_shadertoy1/App.hpp
+++ b/tasks/local_shadertoy1/App.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <etna/Sampler.hpp>
+#include <etna/GlobalContext.hpp>
 #include <etna/Window.hpp>
 #include <etna/PerFrameCmdMgr.hpp>
 #include <etna/ComputePipeline.hpp>
@@ -25,6 +27,10 @@ private:
 
   glm::uvec2 resolution;
   bool useVsync;
+
+  etna::ComputePipeline pipeline;
+  etna::Image image;
+  etna::Sampler defaultSampler;
 
   std::unique_ptr<etna::Window> vkWindow;
   std::unique_ptr<etna::PerFrameCmdMgr> commandManager;

--- a/tasks/local_shadertoy1/shaders/toy.comp
+++ b/tasks/local_shadertoy1/shaders/toy.comp
@@ -1,18 +1,200 @@
 #version 430
 
-layout(local_size_x = 32, local_size_y = 32) in;
+layout(local_size_x = 32, local_size_y = 16) in;
 
 layout(binding = 0, rgba8) uniform image2D resultImage;
+
+const vec2 iResolution = vec2(1280, 720);
+const float iTime = 2.0f;
+
+// --- START SHADERTOY COPYPASTA ---
+const float PI = 3.14159265359;
+
+const vec3 background_color = vec3(0.3, 0.7, 0.9);
+const float shape_tolerance = 1.0; // (0; inf) how smooth will shape transition be
+const float color_mix_sharpness = 10.0; // (1; inf) how sharp will color transition
+const float trefoil_size = 6.0; // how big the whole thing is
+const float radius = 0.5;
+
+struct sphere {
+    vec3 center;
+    float radius;
+    vec3 color;
+};
+
+
+const int n_spheres = 24;
+sphere spheres[n_spheres] = sphere[](
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0))
+);
+
+const bool metal_reflection = false;
+
+
+struct light{
+    vec3 position;
+    float strength;
+    vec3 color;
+};
+
+const int n_lights = 1;
+light lights[n_lights] = light[](
+    light(vec3(0, 0, -100.0), 10000.0, vec3(1, 1, 1))
+);
+
+
+float sphere_sdf(in vec3 point, in vec3 center, in float radius) {
+    return length(point - center) - radius;
+}
+
+// Color weight field - determines how much of a shape's color should be used.
+float sphere_cwf(in vec3 point, in vec3 center, in float radius) {
+    return pow(color_mix_sharpness, radius - (length(point - center)));
+}
+
+float sdf(in vec3 point) {
+    float sum = 0.0;
+    for (int i = 0; i < n_spheres; ++i) {
+        float dist = sphere_sdf(point, spheres[i].center, spheres[i].radius);
+        sum += exp2(-dist / shape_tolerance);
+    }
+    return -shape_tolerance * log2(sum);
+}
+
+vec3 base_color(in vec3 point) {
+    vec3 color_num = vec3(0, 0, 0);
+    vec3 color_denom = vec3(0, 0, 0);
+    for (int i = 0; i < n_spheres; ++i) {
+        float cwf = sphere_cwf(point, spheres[i].center, spheres[i].radius);
+        color_num += spheres[i].color * cwf;
+        color_denom += cwf;
+    }
+    return color_num / color_denom;
+}
+
+bool traceRay(in vec3 ray, in vec3 pos, out vec3 impact_point) {
+    while (true) {
+        float dist = abs(sdf(pos));
+    
+        if (dist < 0.01) {
+            impact_point = pos;
+            return true;
+        }
+        
+        if (dist > 100.0) {
+            return false;
+        }
+        
+        pos += ray * dist;
+    }
+}
+
+vec3 grad(in vec3 point, in float delta) {
+    vec3 dx = vec3(delta, 0, 0);
+    vec3 dy = vec3(0, delta, 0);
+    vec3 dz = vec3(0, 0, delta);
+    float y0 = sdf(point);
+    return (vec3(sdf(point+dx), sdf(point+dy), sdf(point+dz)) - vec3(y0, y0, y0)) / delta;
+}
+
+
+vec3 diffuse(in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray = lights[i].position - point;
+        float intensity = lights[i].strength / pow(length(lightray), 2.0);
+        result += max(dot(normal, normalize(lightray)), 0.0) * intensity * lights[i].color;
+    }
+    result *= base_color;
+    return result;
+}
+
+vec3 specular(in vec3 eye, in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 eye_ray = normalize(eye - point);
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray_refl = -reflect(lights[i].position - point, normal);
+        float intensity = lights[i].strength / pow(length(lightray_refl), 2.0);
+        float powered = pow(max(dot(eye_ray, normalize(lightray_refl)), 0.0), 20.0);
+        result += powered * intensity * lights[i].color;
+    }
+    
+    if (metal_reflection) {
+        result *= base_color;
+    }
+    return result;
+}
+
+void positionSpheres() {
+    for (int i = 0; i < n_spheres; ++i) {
+        float t = iTime + PI * float(i) / float(n_spheres);
+        spheres[i].center = vec3(trefoil_size * cos(3.0 * t) * sin(t) + sin(2.0 * t) * 0.2,
+                                 trefoil_size * cos(3.0 * t) * cos(t) + sin(t) * 0.2,
+                                 33.0 + 30.0 * sin(t * 0.5));
+    }
+}
+
+// --- PAUSE SHADERTOY COPYPASTA
 
 
 void main()
 {
-  ivec2 uv = ivec2(gl_GlobalInvocationID.xy);
+  ivec2 iuv = ivec2(gl_GlobalInvocationID.xy);
 
   // TODO: Put your shadertoy code here!
+
+  // --- CONTINUE SHADERTOY COPYPASTA
+  positionSpheres();
+
+  vec2 uv = (iuv - iResolution.xy / 2.0) / min(iResolution.x, iResolution.y);
+
+  vec3 camera = vec3(0, 0, -1);
+  vec3 ray = normalize(vec3(uv, 0) - camera);
+  vec3 surface_point;
+  vec3 color;
+  if (traceRay(ray, camera, surface_point)) {
+      vec3 base = base_color(surface_point);
+      color = specular(camera, surface_point, base) + diffuse(surface_point, base) + background_color * base * 0.5;
+  } else {
+      color = background_color;
+  }
+  
+  imageStore(resultImage, iuv, vec4(color, 1));
+
+  // --- END SHADERTOY COPYPASTA
+
+  /* --- DEFAULT CODE COMMENTED ---
   // Simple gradient as a test.
   vec3 color = vec3(vec2(uv) / vec2(1280, 720), 0);
 
   if (uv.x < 1280 && uv.y < 720)
     imageStore(resultImage, uv, vec4(color, 1));
+  */
 }

--- a/tasks/local_shadertoy2/App.cpp
+++ b/tasks/local_shadertoy2/App.cpp
@@ -1,0 +1,255 @@
+#include "App.hpp"
+
+#include <etna/Etna.hpp>
+#include <etna/GlobalContext.hpp>
+#include <etna/PipelineManager.hpp>
+#include <etna/RenderTargetStates.hpp>
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+#include <etna/BlockingTransferHelper.hpp>
+#include <iostream>
+#include <ctime>
+
+
+App::App()
+  : resolution{1280, 720}
+  , skinTextureResolution{128, 128}
+  , useVsync{true}
+{
+  {
+    auto glfwInstExts = windowing.getRequiredVulkanInstanceExtensions();
+
+    std::vector<const char*> instanceExtensions{glfwInstExts.begin(), glfwInstExts.end()};
+
+    std::vector<const char*> deviceExtensions{VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+
+    etna::initialize(etna::InitParams{
+      .applicationName = "Local Shadertoy",
+      .applicationVersion = VK_MAKE_VERSION(0, 1, 0),
+      .instanceExtensions = instanceExtensions,
+      .deviceExtensions = deviceExtensions,
+      .physicalDeviceIndexOverride = {},
+      .numFramesInFlight = 1,
+    });
+  }
+
+  osWindow = windowing.createWindow(OsWindow::CreateInfo{
+    .resolution = resolution,
+  });
+
+  {
+    auto surface = osWindow->createVkSurface(etna::get_context().getInstance());
+
+    vkWindow = etna::get_context().createWindow(etna::Window::CreateInfo{
+      .surface = std::move(surface),
+    });
+
+    auto [w, h] = vkWindow->recreateSwapchain(etna::Window::DesiredProperties{
+      .resolution = {resolution.x, resolution.y},
+      .vsync = useVsync,
+    });
+
+    resolution = {w, h};
+  }
+
+  commandManager = etna::get_context().createPerFrameCmdMgr();
+  oneShotManager = etna::get_context().createOneShotCmdMgr();
+
+  {
+    etna::create_program("shadertoy2", {LOCAL_SHADERTOY2_SHADERS_ROOT "toy.vert.spv",
+                                        LOCAL_SHADERTOY2_SHADERS_ROOT "toy.frag.spv" });
+    etna::create_program("skinTexture", {LOCAL_SHADERTOY2_SHADERS_ROOT "toy.vert.spv",
+                                        LOCAL_SHADERTOY2_SHADERS_ROOT "texture.frag.spv" });
+
+    
+    fragVertPipeline = etna::get_context().getPipelineManager().createGraphicsPipeline("shadertoy2",
+      etna::GraphicsPipeline::CreateInfo {
+        .fragmentShaderOutput = {
+          .colorAttachmentFormats = {vk::Format::eB8G8R8A8Srgb}
+        }
+      });
+    
+    skinTexturePipeline = etna::get_context().getPipelineManager().createGraphicsPipeline("skinTexture",
+      etna::GraphicsPipeline::CreateInfo {
+        .fragmentShaderOutput = {
+          .colorAttachmentFormats = {vk::Format::eB8G8R8A8Srgb}
+        }
+      });
+
+    skinTextureImage = etna::get_context().createImage(etna::Image::CreateInfo{
+      .extent = vk::Extent3D{skinTextureResolution.x, skinTextureResolution.y, 1},
+      .name = "skinTexture",
+      .format = vk::Format::eB8G8R8A8Srgb,
+      .imageUsage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled,
+    });
+
+    defaultSampler = etna::Sampler(etna::Sampler::CreateInfo
+      {
+        .filter = vk::Filter::eLinear,
+        .addressMode = vk::SamplerAddressMode::eRepeat,
+        .name = "default_sampler"
+      });
+  }
+}
+
+App::~App()
+{
+  ETNA_CHECK_VK_RESULT(etna::get_context().getDevice().waitIdle());
+}
+
+void App::run()
+{
+  while (!osWindow->isBeingClosed())
+  {
+    windowing.poll();
+
+    drawFrame();
+  }
+
+  ETNA_CHECK_VK_RESULT(etna::get_context().getDevice().waitIdle());
+}
+
+void App::drawFrame()
+{
+  auto currentCmdBuf = commandManager->acquireNext();
+
+  if (!initializedFileTexture) {
+    int x, y, n;
+    unsigned char *picData = stbi_load(TEXTURES_ROOT "texture1.bmp", &x, &y, &n, 4);
+    if (picData == NULL) {
+      throw "texture1.bmp not found";
+    }
+
+    etna::Image::CreateInfo fileTextureInfo{
+      .extent = vk::Extent3D{static_cast<uint32_t>(x), static_cast<uint32_t>(y), 1},
+      .name = "fileTexture",
+      .format = vk::Format::eR8G8B8A8Srgb,
+      .imageUsage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled,
+    };
+    fileTextureImage = etna::create_image_from_bytes(fileTextureInfo, currentCmdBuf, picData);
+
+    stbi_image_free(picData);
+    initializedFileTexture = true;
+  }
+
+  etna::begin_frame();
+
+  auto nextSwapchainImage = vkWindow->acquireNext();
+
+  if (nextSwapchainImage)
+  {
+    auto [backbuffer, backbufferView, backbufferAvailableSem] = *nextSwapchainImage;
+
+    ETNA_CHECK_VK_RESULT(currentCmdBuf.begin(vk::CommandBufferBeginInfo{}));
+    {
+      etna::set_state(
+        currentCmdBuf,
+        skinTextureImage.get(),
+        vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+        vk::AccessFlagBits2::eColorAttachmentWrite,
+        vk::ImageLayout::eColorAttachmentOptimal,
+        vk::ImageAspectFlagBits::eColor);
+      
+      etna::flush_barriers(currentCmdBuf);
+
+      {
+        etna::RenderTargetState state{currentCmdBuf, {{}, {skinTextureResolution.x, skinTextureResolution.y}},
+          {{skinTextureImage.get(), skinTextureImage.getView({})}}, {}};
+        auto skinInfo = etna::get_shader_program("skinTexture");
+
+        currentCmdBuf.bindPipeline(vk::PipelineBindPoint::eGraphics, skinTexturePipeline.getVkPipeline());
+
+        glm::uvec2 res = skinTextureResolution;
+        currentCmdBuf.pushConstants(
+          skinTexturePipeline.getVkPipelineLayout(), vk::ShaderStageFlagBits::eFragment,
+          0, sizeof(res), &res);
+
+        currentCmdBuf.draw(3, 1, 0, 0);
+      }
+
+
+      etna::set_state(
+        currentCmdBuf,
+        skinTextureImage.get(),
+        vk::PipelineStageFlagBits2::eFragmentShader,
+        vk::AccessFlagBits2::eColorAttachmentRead,
+        vk::ImageLayout::eShaderReadOnlyOptimal,
+        vk::ImageAspectFlagBits::eColor);
+      
+      etna::set_state(
+        currentCmdBuf,
+        fileTextureImage.get(),
+        vk::PipelineStageFlagBits2::eFragmentShader,
+        vk::AccessFlagBits2::eColorAttachmentRead,
+        vk::ImageLayout::eShaderReadOnlyOptimal,
+        vk::ImageAspectFlagBits::eColor);
+
+      etna::set_state(
+        currentCmdBuf,
+        backbuffer,
+        vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+        vk::AccessFlagBits2::eColorAttachmentWrite,
+        vk::ImageLayout::eColorAttachmentOptimal,
+        vk::ImageAspectFlagBits::eColor);
+
+      etna::flush_barriers(currentCmdBuf);
+
+      {
+        etna::RenderTargetState state{currentCmdBuf, {{}, {resolution.x, resolution.y}},
+          {{backbuffer, backbufferView}}, {}};
+
+        auto fragVertInfo = etna::get_shader_program("shadertoy2");
+        auto set = etna::create_descriptor_set(
+          fragVertInfo.getDescriptorLayoutId(0),
+          currentCmdBuf,
+          {
+            etna::Binding{0, skinTextureImage.genBinding(defaultSampler.get(), vk::ImageLayout::eShaderReadOnlyOptimal)},
+            etna::Binding{1, fileTextureImage.genBinding(defaultSampler.get(), vk::ImageLayout::eShaderReadOnlyOptimal)}
+          });
+
+        vk::DescriptorSet vkSet = set.getVkSet();
+
+        currentCmdBuf.bindPipeline(vk::PipelineBindPoint::eGraphics, fragVertPipeline.getVkPipeline());
+        currentCmdBuf.bindDescriptorSets(
+          vk::PipelineBindPoint::eGraphics, fragVertPipeline.getVkPipelineLayout(), 0, 1, &vkSet, 0, nullptr);
+
+        glm::uvec2 res = resolution;
+
+        currentCmdBuf.pushConstants(
+          fragVertPipeline.getVkPipelineLayout(), vk::ShaderStageFlagBits::eFragment,
+          0, sizeof(res), &res);
+
+        currentCmdBuf.draw(3, 1, 0, 0);
+      }
+
+      etna::set_state(
+        currentCmdBuf,
+        backbuffer,
+        vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+        {},
+        vk::ImageLayout::ePresentSrcKHR,
+        vk::ImageAspectFlagBits::eColor);
+      etna::flush_barriers(currentCmdBuf);
+    }
+    ETNA_CHECK_VK_RESULT(currentCmdBuf.end());
+
+    auto renderingDone =
+      commandManager->submit(std::move(currentCmdBuf), std::move(backbufferAvailableSem));
+
+    const bool presented = vkWindow->present(std::move(renderingDone), backbufferView);
+
+    if (!presented)
+      nextSwapchainImage = std::nullopt;
+  }
+
+  etna::end_frame();
+
+  if (!nextSwapchainImage && osWindow->getResolution() != glm::uvec2{0, 0})
+  {
+    auto [w, h] = vkWindow->recreateSwapchain(etna::Window::DesiredProperties{
+      .resolution = {resolution.x, resolution.y},
+      .vsync = useVsync,
+    });
+    ETNA_VERIFY((resolution == glm::uvec2{w, h}));
+  }
+}

--- a/tasks/local_shadertoy2/App.hpp
+++ b/tasks/local_shadertoy2/App.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <etna/Sampler.hpp>
+#include <etna/GlobalContext.hpp>
+#include <etna/Window.hpp>
+#include <etna/PerFrameCmdMgr.hpp>
+#include <etna/ComputePipeline.hpp>
+#include <etna/GraphicsPipeline.hpp>
+#include <etna/Image.hpp>
+
+#include "wsi/OsWindowingManager.hpp"
+
+
+class App
+{
+public:
+  App();
+  ~App();
+
+  void run();
+
+private:
+  void drawFrame();
+
+private:
+  OsWindowingManager windowing;
+  std::unique_ptr<OsWindow> osWindow;
+
+  glm::uvec2 resolution;
+  glm::uvec2 skinTextureResolution;
+  bool useVsync;
+
+  etna::GraphicsPipeline skinTexturePipeline;
+  etna::GraphicsPipeline fragVertPipeline;
+  etna::Image skinTextureImage;
+  etna::Image fileTextureImage;
+  etna::Sampler defaultSampler;
+
+  std::unique_ptr<etna::Window> vkWindow;
+  std::unique_ptr<etna::PerFrameCmdMgr> commandManager;
+  std::unique_ptr<etna::OneShotCmdMgr> oneShotManager;
+
+  bool initializedFileTexture = false;
+};

--- a/tasks/local_shadertoy2/CMakeLists.txt
+++ b/tasks/local_shadertoy2/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(local_shadertoy2
+  main.cpp
+  App.cpp
+)
+
+target_link_libraries(local_shadertoy2
+  PRIVATE glfw etna glm::glm wsi gui)
+
+target_add_shaders(local_shadertoy2
+  shaders/toy.vert
+  shaders/toy.frag
+  shaders/texture.frag
+)
+
+target_link_libraries(local_shadertoy2 PUBLIC render_utils scene)
+
+add_compile_definitions(local_shadertoy2 PRIVATE TEXTURES_ROOT="${PROJECT_SOURCE_DIR}/resources/textures/")

--- a/tasks/local_shadertoy2/main.cpp
+++ b/tasks/local_shadertoy2/main.cpp
@@ -1,0 +1,17 @@
+#include "App.hpp"
+
+#include <etna/Etna.hpp>
+
+
+int main()
+{
+  {
+    App app;
+    app.run();
+  }
+
+  if (etna::is_initilized())
+    etna::shutdown();
+
+  return 0;
+}

--- a/tasks/local_shadertoy2/shaders/texture.frag
+++ b/tasks/local_shadertoy2/shaders/texture.frag
@@ -1,0 +1,90 @@
+#version 430
+#extension GL_GOOGLE_include_directive : require
+
+
+#include "cpp_glsl_compat.h"
+
+
+layout(location = 0) out vec4 out_fragColor;
+
+layout(push_constant) uniform params_t
+{
+  uvec2 resolution;
+} params;
+
+
+// code stolen from here: https://www.shadertoy.com/view/lsf3WH
+
+// 0: integer hash
+// 1: float hash (aliasing based) (don't do this unless you live in the year 2013)
+#define METHOD 0
+
+// 0: cubic
+// 1: quintic
+#define INTERPOLANT 0
+
+#if METHOD==0
+float hash( in ivec2 p )  // this hash is not production ready, please
+{                         // replace this by something better
+
+    // 2D -> 1D
+    int n = p.x*3 + p.y*113;
+
+    // 1D hash by Hugo Elias
+	n = (n << 13) ^ n;
+    n = n * (n * n * 15731 + 789221) + 1376312589;
+    return -1.0+2.0*float( n & 0x0fffffff)/float(0x0fffffff);
+}
+#else
+float hash(vec2 p)  // replace this by something better
+{
+    p  = 50.0*fract( p*0.3183099 + vec2(0.71,0.113));
+    return -1.0+2.0*fract( p.x*p.y*(p.x+p.y) );
+}
+#endif
+
+float noise( in vec2 p )
+{
+    #if METHOD==0
+    ivec2 i = ivec2(floor( p ));
+    #else
+    vec2 i = floor( p );
+    #endif
+    vec2 f = fract( p );
+	
+    #if INTERPOLANT==1
+    // quintic interpolant
+    vec2 u = f*f*f*(f*(f*6.0-15.0)+10.0);
+    #else
+    // cubic interpolant
+    vec2 u = f*f*(3.0-2.0*f);
+    #endif    
+
+    #if METHOD==0
+    return mix( mix( hash( i + ivec2(0,0) ), 
+                     hash( i + ivec2(1,0) ), u.x),
+                mix( hash( i + ivec2(0,1) ), 
+                     hash( i + ivec2(1,1) ), u.x), u.y);
+    #else
+    return mix( mix( hash( i + vec2(0.0,0.0) ), 
+                     hash( i + vec2(1.0,0.0) ), u.x),
+                mix( hash( i + vec2(0.0,1.0) ), 
+                     hash( i + vec2(1.0,1.0) ), u.x), u.y);
+    #endif
+}
+
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / params.resolution;
+  
+  float f = 0.0;   
+  uv *= 8.0;
+      mat2 m = mat2( 1.6,  1.2, -1.2,  1.6 );
+  	f  = 0.5000*noise( uv ); uv = m*uv;
+  	f += 0.2500*noise( uv ); uv = m*uv;
+  	f += 0.1250*noise( uv ); uv = m*uv;
+  	f += 0.0625*noise( uv ); uv = m*uv;  
+  f = 0.5 + 0.5*f;
+
+  out_fragColor = vec4( f*0.6, f*0.6, 0., 1.0 );
+}

--- a/tasks/local_shadertoy2/shaders/toy.comp
+++ b/tasks/local_shadertoy2/shaders/toy.comp
@@ -1,0 +1,200 @@
+#version 430
+
+layout(local_size_x = 32, local_size_y = 16) in;
+
+layout(binding = 0, rgba8) uniform image2D resultImage;
+
+const vec2 iResolution = vec2(1280, 720);
+const float iTime = 10.0f;
+
+// --- START SHADERTOY COPYPASTA ---
+const float PI = 3.14159265359;
+
+const vec3 background_color = vec3(0.3, 0.7, 0.9);
+const float shape_tolerance = 1.0; // (0; inf) how smooth will shape transition be
+const float color_mix_sharpness = 10.0; // (1; inf) how sharp will color transition
+const float trefoil_size = 6.0; // how big the whole thing is
+const float radius = 0.5;
+
+struct sphere {
+    vec3 center;
+    float radius;
+    vec3 color;
+};
+
+
+const int n_spheres = 24;
+sphere spheres[n_spheres] = sphere[](
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0))
+);
+
+const bool metal_reflection = false;
+
+
+struct light{
+    vec3 position;
+    float strength;
+    vec3 color;
+};
+
+const int n_lights = 1;
+light lights[n_lights] = light[](
+    light(vec3(0, 0, -100.0), 10000.0, vec3(1, 1, 1))
+);
+
+
+float sphere_sdf(in vec3 point, in vec3 center, in float radius) {
+    return length(point - center) - radius;
+}
+
+// Color weight field - determines how much of a shape's color should be used.
+float sphere_cwf(in vec3 point, in vec3 center, in float radius) {
+    return pow(color_mix_sharpness, radius - (length(point - center)));
+}
+
+float sdf(in vec3 point) {
+    float sum = 0.0;
+    for (int i = 0; i < n_spheres; ++i) {
+        float dist = sphere_sdf(point, spheres[i].center, spheres[i].radius);
+        sum += exp2(-dist / shape_tolerance);
+    }
+    return -shape_tolerance * log2(sum);
+}
+
+vec3 base_color(in vec3 point) {
+    vec3 color_num = vec3(0, 0, 0);
+    vec3 color_denom = vec3(0, 0, 0);
+    for (int i = 0; i < n_spheres; ++i) {
+        float cwf = sphere_cwf(point, spheres[i].center, spheres[i].radius);
+        color_num += spheres[i].color * cwf;
+        color_denom += cwf;
+    }
+    return color_num / color_denom;
+}
+
+bool traceRay(in vec3 ray, in vec3 pos, out vec3 impact_point) {
+    while (true) {
+        float dist = abs(sdf(pos));
+    
+        if (dist < 0.01) {
+            impact_point = pos;
+            return true;
+        }
+        
+        if (dist > 100.0) {
+            return false;
+        }
+        
+        pos += ray * dist;
+    }
+}
+
+vec3 grad(in vec3 point, in float delta) {
+    vec3 dx = vec3(delta, 0, 0);
+    vec3 dy = vec3(0, delta, 0);
+    vec3 dz = vec3(0, 0, delta);
+    float y0 = sdf(point);
+    return (vec3(sdf(point+dx), sdf(point+dy), sdf(point+dz)) - vec3(y0, y0, y0)) / delta;
+}
+
+
+vec3 diffuse(in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray = lights[i].position - point;
+        float intensity = lights[i].strength / pow(length(lightray), 2.0);
+        result += max(dot(normal, normalize(lightray)), 0.0) * intensity * lights[i].color;
+    }
+    result *= base_color;
+    return result;
+}
+
+vec3 specular(in vec3 eye, in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 eye_ray = normalize(eye - point);
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray_refl = -reflect(lights[i].position - point, normal);
+        float intensity = lights[i].strength / pow(length(lightray_refl), 2.0);
+        float powered = pow(max(dot(eye_ray, normalize(lightray_refl)), 0.0), 20.0);
+        result += powered * intensity * lights[i].color;
+    }
+    
+    if (metal_reflection) {
+        result *= base_color;
+    }
+    return result;
+}
+
+void positionSpheres() {
+    for (int i = 0; i < n_spheres; ++i) {
+        float t = iTime + PI * float(i) / float(n_spheres);
+        spheres[i].center = vec3(trefoil_size * cos(3.0 * t) * sin(t) + sin(2.0 * t) * 0.2,
+                                 trefoil_size * cos(3.0 * t) * cos(t) + sin(t) * 0.2,
+                                 33.0 + 30.0 * sin(t * 0.5));
+    }
+}
+
+// --- PAUSE SHADERTOY COPYPASTA
+
+
+void main()
+{
+  ivec2 iuv = ivec2(gl_GlobalInvocationID.xy);
+
+  // TODO: Put your shadertoy code here!
+
+  // --- CONTINUE SHADERTOY COPYPASTA
+  positionSpheres();
+
+  vec2 uv = (iuv - iResolution.xy / 2.0) / min(iResolution.x, iResolution.y);
+
+  vec3 camera = vec3(0, 0, -1);
+  vec3 ray = normalize(vec3(uv, 0) - camera);
+  vec3 surface_point;
+  vec3 color;
+  if (traceRay(ray, camera, surface_point)) {
+      vec3 base = base_color(surface_point);
+      color = specular(camera, surface_point, base) + diffuse(surface_point, base) + background_color * base * 0.5;
+  } else {
+      color = background_color;
+  }
+  
+  imageStore(resultImage, iuv, vec4(color, 1));
+
+  // --- END SHADERTOY COPYPASTA
+
+  /* --- DEFAULT CODE COMMENTED ---
+  // Simple gradient as a test.
+  vec3 color = vec3(vec2(uv) / vec2(1280, 720), 0);
+
+  if (uv.x < 1280 && uv.y < 720)
+    imageStore(resultImage, uv, vec4(color, 1));
+  */
+}

--- a/tasks/local_shadertoy2/shaders/toy.frag
+++ b/tasks/local_shadertoy2/shaders/toy.frag
@@ -1,0 +1,217 @@
+#version 430
+#extension GL_GOOGLE_include_directive : require
+
+
+#include "cpp_glsl_compat.h"
+
+
+layout(binding = 0) uniform sampler2D iChannel0;
+layout(binding = 1) uniform sampler2D fileTexture;
+
+layout(location = 0) out vec4 out_fragColor;
+
+layout(push_constant) uniform params_t
+{
+  uvec2 resolution;
+} params;
+
+
+const float iTime = 10.0f;
+
+const float PI = 3.14159265359;
+
+const float shape_tolerance = 1.0; // (0; inf) how smooth will shape transition be
+const float color_mix_sharpness = 10.; // (1; inf) how sharp will color transition
+const float trefoil_size = 6.0; // how big the whole thing is
+const float radius = 0.5;
+
+
+struct sphere {
+    vec3 center;
+    float radius;
+    vec3 color;
+};
+
+
+const int n_spheres = 24;
+sphere spheres[n_spheres] = sphere[](
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(1.0, 0.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 1.0, 0.0)),
+    sphere(vec3(0, 0, 0), radius, vec3(0.0, 0.0, 1.0))
+);
+
+const bool metal_reflection = false;
+
+
+struct light{
+    vec3 position;
+    float strength;
+    vec3 color;
+};
+
+const int n_lights = 1;
+light lights[n_lights] = light[](
+    light(vec3(0, 0, -100.0), 10000.0, vec3(1, 1, 1))
+);
+
+vec3 grad(in vec3 point, in float delta);
+
+float sphere_sdf(in vec3 point, in vec3 center, in float radius) {
+    return length(point - center) - radius;
+}
+
+// Color weight field - determines how much of a shape's color should be used.
+float sphere_cwf(in vec3 point, in vec3 center, in float radius) {
+    return pow(color_mix_sharpness, radius - (length(point - center)));
+}
+
+float sdf(in vec3 point) {
+    float sum = 0.0;
+    for (int i = 0; i < n_spheres; ++i) {
+        float dist = sphere_sdf(point, spheres[i].center, spheres[i].radius);
+        sum += exp2(-dist / shape_tolerance);
+    }
+    return -shape_tolerance * log2(sum);
+}
+
+vec3 get_sphere_texture_color(in sphere sph, in vec3 point) {
+    point -= sph.center + vec3(2.0);
+    point /= 20.0;
+    vec3 normal = normalize(abs(point * 20.0 + vec3(2.0)));
+    vec3 result_procedural = normal.x * texture(iChannel0, point.yz).rgb +
+    normal.y * texture(iChannel0, point.xz).rgb +
+    normal.z * texture(iChannel0, point.xy).rgb;
+    vec3 result_file = normal.x * texture(fileTexture, point.yz).rgb +
+    normal.y * texture(fileTexture, point.xz).rgb +
+    normal.z * texture(fileTexture, point.xy).rgb;
+
+    float mix_factor = 0.5f;
+    vec3 result = mix_factor * result_procedural + (1.0f - mix_factor) * result_file;
+    return result * 1.5;
+}
+
+vec3 base_color(in vec3 point) {
+    vec3 color_num = vec3(0, 0, 0);
+    vec3 color_denom = vec3(0, 0, 0);
+    for (int i = 0; i < n_spheres; ++i) {
+        float cwf = sphere_cwf(point, spheres[i].center, spheres[i].radius);
+        color_num += get_sphere_texture_color(spheres[i], point) * cwf;
+        color_denom += cwf;
+    }
+    return color_num / color_denom;
+}
+
+bool traceRay(in vec3 ray, in vec3 pos, out vec3 impact_point) {
+    while (true) {
+        float dist = abs(sdf(pos));
+    
+        if (dist < 0.01) {
+            impact_point = pos;
+            return true;
+        }
+        
+        if (dist > 100.0) {
+            return false;
+        }
+        
+        pos += ray * dist;
+    }
+}
+
+vec3 grad(in vec3 point, in float delta) {
+    vec3 dx = vec3(delta, 0, 0);
+    vec3 dy = vec3(0, delta, 0);
+    vec3 dz = vec3(0, 0, delta);
+    float y0 = sdf(point);
+    return (vec3(sdf(point+dx), sdf(point+dy), sdf(point+dz)) - vec3(y0, y0, y0)) / delta;
+}
+
+
+vec3 diffuse(in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray = lights[i].position - point;
+        float intensity = lights[i].strength / pow(length(lightray), 2.0);
+        result += max(dot(normal, normalize(lightray)), 0.0) * intensity * lights[i].color;
+    }
+    result *= base_color;
+    return result;
+}
+
+vec3 specular(in vec3 eye, in vec3 point, in vec3 base_color) {
+    vec3 normal = normalize(grad(point, 0.0001));
+    vec3 eye_ray = normalize(eye - point);
+    vec3 result = vec3(0, 0, 0);
+    
+    for (int i = 0; i < n_lights; ++i) {
+        vec3 lightray_refl = -reflect(lights[i].position - point, normal);
+        float intensity = lights[i].strength / pow(length(lightray_refl), 2.0);
+        float powered = pow(max(dot(eye_ray, normalize(lightray_refl)), 0.0), 20.0);
+        result += powered * intensity * lights[i].color;
+    }
+    
+    if (metal_reflection) {
+        result *= base_color;
+    }
+    return result;
+}
+
+void positionSpheres() {
+    for (int i = 0; i < n_spheres; ++i) {
+        //float t = iTime + PI * float(i) / float(n_spheres);
+        float t = iTime + PI * float(i) / float(n_spheres);
+        spheres[i].center = vec3(trefoil_size * cos(3.0 * t) * sin(t) + sin(2.0 * t) * 0.2,
+                                 trefoil_size * cos(3.0 * t) * cos(t) + sin(t) * 0.2,
+                                 36.0 + 30.0 * sin(t * 0.5 + PI / 4.));
+    }
+}
+
+vec3 skybox_color(in vec3 direction) {
+    // return texture(iChannel1, direction).rgb;
+    return vec3(0.3, 0.05, 0.05);
+}
+
+
+void main() {
+  positionSpheres();
+
+  vec2 uv = (gl_FragCoord.xy - params.resolution.xy / 2.0) / min(params.resolution.x, params.resolution.y);
+
+  vec3 camera = vec3(0, 0, -1);
+  vec3 ray = normalize(vec3(uv, 0) - camera);
+  vec3 surface_point;
+  vec3 color;
+  if (traceRay(ray, camera, surface_point)) {
+      vec3 base = base_color(surface_point);
+      vec3 normal = normalize(grad(surface_point, 0.0001));
+      vec3 skyray = reflect(ray, normal);
+      color = specular(camera, surface_point, base) + diffuse(surface_point, base);
+  } else {
+      color = skybox_color(ray);
+  }
+  
+  out_fragColor = vec4(color, 1.0f);
+}

--- a/tasks/local_shadertoy2/shaders/toy.vert
+++ b/tasks/local_shadertoy2/shaders/toy.vert
@@ -1,0 +1,17 @@
+#version 430
+#extension GL_GOOGLE_include_directive : require
+
+
+#include "cpp_glsl_compat.h"
+
+
+void main(void)
+{
+  if (gl_VertexIndex == 0) {
+    gl_Position = vec4(-1.0f, -1.0f, 0.0f, 1.0f);
+  } else if (gl_VertexIndex == 1) {
+    gl_Position = vec4(3.0f, -1.0f, 0.0f, 1.0f);
+  } else {
+    gl_Position = vec4(-1.0f, 3.0f, 0.0f, 1.0f);
+  }
+}


### PR DESCRIPTION
Делал неаккуратным способом, то есть не использовал `etna::GpuSharedResource`, а просто массив из буферов. Но так не очень грязно даже получилось.
Строки 242-250 `tasks/inflight_frames/App.cpp` - карусель буферов.
Артефакты без карусели буферов наблюдал, белый кружочек рвался на куски, клонировался и исчезал.
С ними - нет.
Строки 126-134 `tasks/inflight_frames/shaders/toy.frag` - регулировка фальшивой нагрузки на gpu.
На tracy предполагаемые эффекты видел, ускорение после выключения vsync и после добавления кадров в полёте.